### PR TITLE
Fix handling of time_to_live parameter to avoid NPE

### DIFF
--- a/src/main/java/net/atarno/vertx/gcm/server/GCMServer.java
+++ b/src/main/java/net/atarno/vertx/gcm/server/GCMServer.java
@@ -111,8 +111,10 @@ public class GCMServer extends BusModBase implements Handler<Message<JsonObject>
             return;
         }
 
-        int ttl = n.getInteger( "time_to_live" );
-        if ( ttl > gcm_max_seconds_to_leave ) {
+        Integer ttl = n.getInteger( "time_to_live" );
+        if (ttl == null) {
+            ttl = gcm_max_seconds_to_leave;
+        } else if ( ttl > gcm_max_seconds_to_leave ) {
             sendError( message, "Max value of 'time_to_live' exceeded: " + ttl + " > " + gcm_max_seconds_to_leave );
             return;
         }


### PR DESCRIPTION
According to documentation, time_to_live should be optimal, defaulting to maximum (4 weeks). However, when a message is sent to the vertx-gcm busmod without this parameter, it crashes on NPE.

The reason is, that the value is read into java int primitive, which cannot handle null values. I modified the code so that the null value is accepted and the parameter is set to default (max) value instead.
